### PR TITLE
Update references from skills-dev to skills organization

### DIFF
--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -18,9 +18,9 @@ Here's a recap of your accomplishments:
 
 Want to keep going? Try one of these other exercises! :octocat:
 
-[![Skills](https://img.shields.io/badge/Skills-Review_Pull_Requests_→-text?style=flat&logo=github&labelColor=1f2328&color=1f883d)](https://github.com/skills-dev/review-pull-requests)
+[![Skills](https://img.shields.io/badge/Skills-Review_Pull_Requests_→-text?style=flat&logo=github&labelColor=1f2328&color=1f883d)](https://github.com/skills/review-pull-requests)
 
-[![Skills](https://img.shields.io/badge/Skills-Resolve_Merge_Conflicts_→-text?style=flat&logo=github&labelColor=1f2328&color=1f883d)](https://github.com/skills-dev/resolve-merge-conflicts)
+[![Skills](https://img.shields.io/badge/Skills-Resolve_Merge_Conflicts_→-text?style=flat&logo=github&labelColor=1f2328&color=1f883d)](https://github.com/skills/resolve-merge-conflicts)
 
 
 ### Other Resources


### PR DESCRIPTION
## Summary

This PR updates all references from the `skills-dev` organization to the `skills` organization.

## Context

We have merged all repositories from the `skills-dev` organization into the main `skills` organization. This PR updates any links and references that still point to `skills-dev` to ensure they point to the correct organization.

## Changes

- Updated repository references from `skills-dev` to `skills`
- No functional changes, only URL/reference updates